### PR TITLE
modify files sort

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,10 +36,9 @@ module.exports = {
         },
         ( err, files ) => {
           files.sort((a, b) => {
-            const sameDir = path.dirname(a) == path.dirname(b)
-            if (sameDir && isReadme(a))
+            if (path.dirname(b).includes(path.dirname(a)) && isReadme(a))
               return -1
-            if (sameDir && isReadme(b))
+            if (path.dirname(a).includes(path.dirname(b)) && isReadme(b))
               return 1
             return a < b ? -1 : a > b ? 1 : 0
           })


### PR DESCRIPTION
solve the problem of the issue:
 The files sort may cause that the README.md file is after the child directory #8

test case as following:
Abc/README.md, isReadme: true
Abc/Abcd/README.md, isReadme: true
Abc/Abcd/Testd.md, isReadme: false
Abc/TEST.md, isReadme: false

Abc/README.md, isReadme: true 
this file is the dictionary, so it's should be the first one.