### PR TITLE
Add pretty formatting to titles

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -41,7 +41,7 @@ const getPaths = (config, pattern) =>
     pattern,
     {
       cwd: config.root,
-      ignore: [ 'node_modules/**', '_book' ],
+      ignore: [ 'node_modules/**', '_book', 'styles' ],
       nosort: true
     }
   )

--- a/fs.js
+++ b/fs.js
@@ -41,7 +41,7 @@ const getPaths = (config, pattern) =>
     pattern,
     {
       cwd: config.root,
-      ignore: [ 'node_modules/**', '_book', 'styles', '_layouts', '_layouts/website' ],
+      ignore: [ 'node_modules/**', '_book', 'styles', '_layouts', '_layouts/website', 'img' ],
       nosort: true
     }
   )

--- a/fs.js
+++ b/fs.js
@@ -41,7 +41,7 @@ const getPaths = (config, pattern) =>
     pattern,
     {
       cwd: config.root,
-      ignore: [ 'node_modules/**', '_book', 'styles', '_layouts', '_layouts/website', 'img' ],
+      ignore: [ 'node_modules/**', '_book', 'styles', '_layouts', '_layouts/website', '**/img' ],
       nosort: true
     }
   )

--- a/fs.js
+++ b/fs.js
@@ -41,7 +41,7 @@ const getPaths = (config, pattern) =>
     pattern,
     {
       cwd: config.root,
-      ignore: [ 'node_modules/**', '_book', 'styles' ],
+      ignore: [ 'node_modules/**', '_book', 'styles', '_layouts' ],
       nosort: true
     }
   )

--- a/fs.js
+++ b/fs.js
@@ -41,7 +41,7 @@ const getPaths = (config, pattern) =>
     pattern,
     {
       cwd: config.root,
-      ignore: [ 'node_modules/**', '_book', 'styles', '_layouts', 'website' ],
+      ignore: [ 'node_modules/**', '_book', 'styles', '_layouts', '_layouts/website' ],
       nosort: true
     }
   )

--- a/fs.js
+++ b/fs.js
@@ -41,7 +41,7 @@ const getPaths = (config, pattern) =>
     pattern,
     {
       cwd: config.root,
-      ignore: [ 'node_modules/**', '_book', 'styles', '_layouts' ],
+      ignore: [ 'node_modules/**', '_book', 'styles', '_layouts', 'website' ],
       nosort: true
     }
   )

--- a/renderer.js
+++ b/renderer.js
@@ -35,8 +35,7 @@ const fileEntry = isReadme => ([ filePath, parsedMarkdown ]) => {
   if (isReadme(filePath)) return
 
   const depth = getFileDepth(filePath)
-  const fileTitle = getFileTitle(parsedMarkdown)
-    .getOrElse(formatTitle(getFileName(filePath)))
+  const fileTitle = formatTitle(getFileName(filePath))
 
   return linkEntries(depth, fileTitle, filePath)
 }

--- a/renderer.js
+++ b/renderer.js
@@ -18,7 +18,12 @@ const dirEntry = readmeFilename => ([ dirPath, hasReadme ]) => {
 const getDirTitle = path =>
   Maybe.of(path.split('/'))
     .chain(x => Maybe.fromNullable(x[x.length - 2]))
+    .map(title => formatTitle(title))
     .getOrElse('NO_NAME') // shouldn't happen, right !?
+
+const formatTitle = title =>
+  title.replace(/^[0-9]*-/,'')
+    .replace(/(_|-)/g,' ').replace(/.md$/,"").replace(/\b\w/g, l => l.toUpperCase())
 
 const getFileName = path =>
   Maybe.of(path.split('/'))
@@ -31,7 +36,7 @@ const fileEntry = isReadme => ([ filePath, parsedMarkdown ]) => {
 
   const depth = getFileDepth(filePath)
   const fileTitle = getFileTitle(parsedMarkdown)
-    .getOrElse(getFileName(filePath))
+    .getOrElse(formatTitle(getFileName(filePath)))
 
   return linkEntries(depth, fileTitle, filePath)
 }


### PR DESCRIPTION
The title pulled from the directory name or file name is prettified by removing "_" (underscores), "-" (dashes), ".md" (the extension) and any prefixed ordering numbers.