### PR TITLE
Ignore the styles folder

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -41,7 +41,7 @@ const getPaths = (config, pattern) =>
     pattern,
     {
       cwd: config.root,
-      ignore: [ 'node_modules/**', '_book' ],
+      ignore: [ 'node_modules/**', '_book', 'styles' ],
       nosort: true
     }
   )

--- a/renderer.js
+++ b/renderer.js
@@ -30,8 +30,7 @@ const fileEntry = isReadme => ([ filePath, parsedMarkdown ]) => {
   if (isReadme(filePath)) return
 
   const depth = getFileDepth(filePath)
-  const fileTitle = getFileTitle(parsedMarkdown)
-    .getOrElse(getFileName(filePath))
+  const fileTitle = getFileName(filePath)
 
   return linkEntries(depth, fileTitle, filePath)
 }


### PR DESCRIPTION
The styles folder is only to define additional CSS and should not be included in the summary.

(afterthought, I think the folder name/filename can be overriden in the configuration hence maybe this shouldn't be hardcoded)