### PR TITLE
Show Introduction before section

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -51,6 +51,7 @@ const readFile = config => ([ path ]) =>
   fs.readFileSync(`${config.root}/${path}`, { encoding: 'utf8' })
 
 const writeSummaryFile = config => summaryContent => {
+  summaryContent = '\n- [Introduction](README.md)\n' + summaryContent
   fs.writeFileSync(`${config.root}/${config.summaryFilename}`, summaryContent, { encoding: 'utf8' })
 }
 


### PR DESCRIPTION
when directory generated as a section, Introduction will show as a normal link after the first section.

This pr is to make the Introduction show in the first order, not after the first section(if there is).